### PR TITLE
Fix crash if pdf is corrupted

### DIFF
--- a/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
+++ b/pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt
@@ -99,8 +99,12 @@ class PdfRendererView @JvmOverloads constructor(
                 statusListener?.onPdfLoadProgress(progress, currentBytes, totalBytes)
             }
             override fun onDownloadSuccess(downloadedFile: File) {
-                initWithFile(File(downloadedFile.absolutePath),cacheStrategy)
-                statusListener?.onPdfLoadSuccess(downloadedFile.absolutePath)
+                try {
+                    initWithFile(File(downloadedFile.absolutePath), cacheStrategy)
+                    statusListener?.onPdfLoadSuccess(downloadedFile.absolutePath)
+                } catch (e: Exception) {
+                    statusListener?.onError(e)
+                }
             }
             override fun onError(error: Throwable) {
                 error.printStackTrace()


### PR DESCRIPTION
This pull request includes a change to the `PdfRendererView` class in the `pdfViewer` module. The change adds error handling to the `onDownloadSuccess` method to catch exceptions and notify the status listener of any errors.

Error handling improvement:

* [`pdfViewer/src/main/java/com/rajat/pdfviewer/PdfRendererView.kt`](diffhunk://#diff-3b5595e2cb809cdc88d4486659a1addf4ad923a1473eb1b5e36a0d9b55f015c8R102-R107): Wrapped the initialization code in a try-catch block within the `onDownloadSuccess` method to handle potential exceptions and call `statusListener?.onError(e)` if an error occurs.